### PR TITLE
Port to .NET Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.resources
 *.vs10x
 *_ReSharper.*
+.vs
 
 
 ###### Binary files
@@ -19,6 +20,11 @@
 *.cache
 *.sln.proj
 *.nupkg
+
+
+###### DNX
+project.lock.json
+artifacts
 
 
 ###### Custom NAnt configuration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+build:
+  project: src/NGettext.sln

--- a/src/NGettext.Tests/BaseCatalogTest.cs
+++ b/src/NGettext.Tests/BaseCatalogTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Globalization;
 

--- a/src/NGettext.Tests/BaseCatalogTest.cs
+++ b/src/NGettext.Tests/BaseCatalogTest.cs
@@ -16,7 +16,7 @@ namespace NGettext.Tests
 		[SetUp]
 		public void Init()
 		{
-			
+
 		}
 
 		#region GetString
@@ -64,7 +64,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestGetPluralString()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("en-US"));
+			var t = new EmptyBaseCatalog(new CultureInfo("en-US"));
 			t.Translations.Add("key1", new[] {"value1"});
 			t.Translations.Add("key2plural1", new[] {"value2plural1", "value2plural2"});
 
@@ -79,7 +79,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestGetPluralStringFormat()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("en-US"));
+			var t = new EmptyBaseCatalog(new CultureInfo("en-US"));
 
 			Assert.AreEqual("You have 1 apple", t.GetPluralString("You have {0} apple", "You have {0} apples", 1, 1));
 			Assert.AreEqual("You have 2 apples", t.GetPluralString("You have {0} apple", "You have {0} apples", 2, 2));
@@ -93,7 +93,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestGetPluralStringInternational()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("ru-RU"));
+			var t = new EmptyBaseCatalog(new CultureInfo("ru-RU"));
 			t.Translations.Add("You have {0} apple", new[] { "У Вас {0} яблоко", "У Вас {0} яблока", "У Вас {0} яблок" });
 
 			Assert.AreEqual("У Вас 1 яблоко", t.GetPluralString("You have {0} apple", "You have {0} apples", 1, 1));
@@ -162,7 +162,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestGetParticularPluralString()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("en-US"));
+			var t = new EmptyBaseCatalog(new CultureInfo("en-US"));
 			t.Translations.Add("context1" + BaseCatalog.CONTEXT_GLUE + "key1-1", new[] { "value1-1", "value1-2" });
 			t.Translations.Add("context2" + BaseCatalog.CONTEXT_GLUE + "key1-1", new[] { "value2-1", "value2-2" });
 
@@ -175,7 +175,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestGetParticularPluralStringFormat()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("en-US"));
+			var t = new EmptyBaseCatalog(new CultureInfo("en-US"));
 
 			Assert.AreEqual("Foo bar", t.GetParticularPluralString("context", "Foo {0}", "Bar {0}", 1, "bar"));
 			Assert.AreEqual("Bar bar", t.GetParticularPluralString("context", "Foo {0}", "Bar {0}", 2, "bar"));
@@ -211,7 +211,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestProtectedGetPluralString()
 		{
-			var t = new EmptyBaseCatalog(CultureInfo.CreateSpecificCulture("en-US"));
+			var t = new EmptyBaseCatalog(new CultureInfo("en-US"));
 			t.Translations.Add("key1", new[] { "value1" });
 
 			Assert.AreEqual("value1", t.GetPluralStringDefault("key1", "defaultSingular", "defaultPlural", 1));

--- a/src/NGettext.Tests/CatalogTest.cs
+++ b/src/NGettext.Tests/CatalogTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Globalization;
 using System.IO;
@@ -18,8 +17,7 @@ namespace NGettext.Tests
 		[SetUp]
 		public void Init()
 		{
-			//this.LocalesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
-			this.LocalesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
+			this.LocalesDir = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestResources", "locales"));
 		}
 
 		[Test]
@@ -37,7 +35,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestStream()
 		{
-			using (var stream = File.OpenRead(Path.Combine(this.LocalesDir, "ru_RU", "LC_MESSAGES", "Test.mo")))
+			using (var stream = File.OpenRead(Path.Combine(this.LocalesDir, Path.Combine("ru_RU", Path.Combine("LC_MESSAGES", "Test.mo")))))
 			{
 				var t = new Catalog(stream, new CultureInfo("ru-RU"));
 				this._TestLoadedTranslation(t);

--- a/src/NGettext.Tests/CatalogTest.cs
+++ b/src/NGettext.Tests/CatalogTest.cs
@@ -18,7 +18,8 @@ namespace NGettext.Tests
 		[SetUp]
 		public void Init()
 		{
-			this.LocalesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			//this.LocalesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			this.LocalesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
 		}
 
 		[Test]
@@ -29,8 +30,8 @@ namespace NGettext.Tests
 			Assert.AreEqual(0, t.Translations.Count);
 			Assert.AreEqual(CultureInfo.CurrentUICulture, t.CultureInfo);
 
-			t = new Catalog(CultureInfo.CreateSpecificCulture("fr"));
-			Assert.AreEqual(CultureInfo.CreateSpecificCulture("fr"), t.CultureInfo);
+			t = new Catalog(new CultureInfo("fr"));
+			Assert.AreEqual(new CultureInfo("fr"), t.CultureInfo);
 		}
 
 		[Test]
@@ -38,7 +39,7 @@ namespace NGettext.Tests
 		{
 			using (var stream = File.OpenRead(Path.Combine(this.LocalesDir, "ru_RU", "LC_MESSAGES", "Test.mo")))
 			{
-				var t = new Catalog(stream, CultureInfo.CreateSpecificCulture("ru-RU"));
+				var t = new Catalog(stream, new CultureInfo("ru-RU"));
 				this._TestLoadedTranslation(t);
 			}
 		}
@@ -46,7 +47,7 @@ namespace NGettext.Tests
 		[Test]
 		public void TestLocaleDir()
 		{
-			var t = new Catalog("Test", this.LocalesDir, CultureInfo.CreateSpecificCulture("ru-RU"));
+			var t = new Catalog("Test", this.LocalesDir, new CultureInfo("ru-RU"));
 			this._TestLoadedTranslation(t);
 		}
 

--- a/src/NGettext.Tests/Loaders/MoFileParserTest.cs
+++ b/src/NGettext.Tests/Loaders/MoFileParserTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.IO;
 using System.Reflection;
@@ -14,12 +13,18 @@ namespace NGettext.Tests.Loaders
 	[TestFixture]
 	public class MoFileParserTest
 	{
+		public string LocalesDir;
+
+		[SetUp]
+		public void Init()
+		{
+			this.LocalesDir = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestResources", "locales"));
+		}
+
 		[Test]
 		public void TestParsing()
 		{
-			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
-			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
-			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test.mo")))
+			using (var stream = File.OpenRead(Path.Combine(LocalesDir, Path.Combine("ru_RU", Path.Combine("LC_MESSAGES", "Test.mo")))))
 			{
 				var parser = new MoFileParser();
 				parser.Parse(stream);
@@ -30,9 +35,7 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestBigEndianParsing()
 		{
-			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
-			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
-			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_BigEndian.mo")))
+			using (var stream = File.OpenRead(Path.Combine(LocalesDir, Path.Combine("ru_RU", Path.Combine("LC_MESSAGES", "Test_BigEndian.mo")))))
 			{
 				var parser = new MoFileParser();
 				parser.Parse(stream);
@@ -43,9 +46,7 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestAutoEncoding()
 		{
-			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
-			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
-			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_KOI8-R.mo")))
+			using (var stream = File.OpenRead(Path.Combine(LocalesDir, Path.Combine("ru_RU", Path.Combine("LC_MESSAGES", "Test_KOI8-R.mo")))))
 			{
 				var parser = new MoFileParser();
 				parser.Parse(stream);
@@ -56,9 +57,7 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestManualEncoding()
 		{
-			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
-			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
-			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_KOI8-R.mo")))
+			using (var stream = File.OpenRead(Path.Combine(LocalesDir, Path.Combine("ru_RU", Path.Combine("LC_MESSAGES", "Test_KOI8-R.mo")))))
 			{
 				var parser = new MoFileParser()
 				{

--- a/src/NGettext.Tests/Loaders/MoFileParserTest.cs
+++ b/src/NGettext.Tests/Loaders/MoFileParserTest.cs
@@ -17,7 +17,8 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestParsing()
 		{
-			var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
 			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test.mo")))
 			{
 				var parser = new MoFileParser();
@@ -29,7 +30,8 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestBigEndianParsing()
 		{
-			var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
 			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_BigEndian.mo")))
 			{
 				var parser = new MoFileParser();
@@ -41,7 +43,8 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestAutoEncoding()
 		{
-			var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
 			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_KOI8-R.mo")))
 			{
 				var parser = new MoFileParser();
@@ -53,7 +56,8 @@ namespace NGettext.Tests.Loaders
 		[Test]
 		public void TestManualEncoding()
 		{
-			var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			//var localesDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestResources", "locales");
+			var localesDir = Path.Combine(Directory.GetCurrentDirectory(), "TestResources", "locales");
 			using (var stream = File.OpenRead(Path.Combine(localesDir, "ru_RU", "LC_MESSAGES", "Test_KOI8-R.mo")))
 			{
 				var parser = new MoFileParser()

--- a/src/NGettext.Tests/NGettext.Tests.xproj
+++ b/src/NGettext.Tests/NGettext.Tests.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4521064c-c0f2-4511-8552-dd7330f3d231</ProjectGuid>
+    <RootNamespace>NGettext.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\NGettext\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\NGettext\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
+++ b/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using NGettext.Plural;
 using NUnit.Framework;
@@ -11,7 +10,6 @@ namespace NGettext.Tests.Plural
 	[TestFixture]
 	public class DefaultPluralRuleGeneratorTest
 	{
-
 		[SetUp]
 		public void Init()
 		{

--- a/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
+++ b/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
@@ -85,7 +85,7 @@ namespace NGettext.Tests.Plural
 							{10, 2},
 							{999, 2},
 						}},
-					{"se-SE", new Dictionary<long, int>()
+					{"se", new Dictionary<long, int>()
 						{
 							{0, 2},
 							{1, 0},

--- a/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
+++ b/src/NGettext.Tests/Plural/DefaultPluralRuleGeneratorTest.cs
@@ -110,7 +110,7 @@ namespace NGettext.Tests.Plural
 			var generator = new DefaultPluralRuleGenerator();
 			foreach (var testCase in dict)
 			{
-				var locale = CultureInfo.CreateSpecificCulture(testCase.Key);
+				var locale = new CultureInfo(testCase.Key);
 				var rule = generator.CreateRule(locale);
 				foreach (var data in testCase.Value)
 				{

--- a/src/NGettext.Tests/Plural/PluralRuleTest.cs
+++ b/src/NGettext.Tests/Plural/PluralRuleTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using NGettext.Plural;
 using NUnit.Framework;

--- a/src/NGettext.Tests/Program.cs
+++ b/src/NGettext.Tests/Program.cs
@@ -1,0 +1,24 @@
+﻿using NUnitLite;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NGettext.Tests
+{
+	public class Program
+	{
+		// http://www.alteridem.net/2015/11/04/testing-net-core-using-nunit-3/
+		public static int Main(string[] args)
+		{
+#if DNXCORE50
+
+			return new AutoRun().Execute(typeof(Program).GetTypeInfo().Assembly, Console.Out, Console.In, args);
+#else
+			return new AutoRun().Execute(args);
+#endif
+		}
+	}
+}

--- a/src/NGettext.Tests/Program.cs
+++ b/src/NGettext.Tests/Program.cs
@@ -1,10 +1,8 @@
 ﻿using NUnitLite;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace NGettext.Tests
 {

--- a/src/NGettext.Tests/Properties/AssemblyInfo.cs
+++ b/src/NGettext.Tests/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Tests")]
@@ -14,22 +14,24 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+#if !DNXCORE50
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("963df97c-de1a-4860-aae0-8657970d165c")]
+#endif
 
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/src/NGettext.Tests/Stabs/EmptyBaseCatalog.cs
+++ b/src/NGettext.Tests/Stabs/EmptyBaseCatalog.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Globalization;
 

--- a/src/NGettext.Tests/project.json
+++ b/src/NGettext.Tests/project.json
@@ -11,12 +11,6 @@
     },
 
     "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Globalization": "4.0.11-beta-23516",
-        "System.Collections": "4.0.0-beta-23019",
-        "System.IO": "4.0.11-beta-23516",
-        "System.Linq": "4.0.1-beta-23516",
-
         "NUnit": "3.0.0",
         "NUnitLite": "3.0.0",
 
@@ -28,12 +22,18 @@
     },
 
     "frameworks": {
+        "net20": { },
         "net45": { },
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
+                "System.Runtime": "4.0.21-beta-23516",
+                "System.Globalization": "4.0.11-beta-23516",
+                "System.Collections": "4.0.0-beta-23019",
+                "System.IO": "4.0.11-beta-23516",
                 "System.Console": "4.0.0-beta-23516",
-                "System.Text.Encoding.CodePages": "4.0.1-beta-23516"
+                "System.Text.Encoding.CodePages": "4.0.1-beta-23516",
+                "System.Reflection": "4.1.0-beta-23516"
             }
         }
     }

--- a/src/NGettext.Tests/project.json
+++ b/src/NGettext.Tests/project.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.0-rc1-*",
+    "description": "NGettext",
+    "authors": [ "Neris Ereptoris" ],
+    "tags": [ "gettext", "i18n", "localization" ],
+    "projectUrl": "https://github.com/neris/NGettext",
+    "licenseUrl": "https://github.com/neris/NGettext/blob/master/LICENSE",
+
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Globalization": "4.0.11-beta-23516",
+        "System.Collections": "4.0.0-beta-23019",
+        "System.IO": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+
+        "NUnit": "3.0.0",
+        "NUnitLite": "3.0.0",
+
+        "NGettext": ""
+    },
+
+    "commands": {
+        "test": "NGettext.Tests"
+    },
+
+    "frameworks": {
+        "net45": { },
+        "dnx451": { },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Console": "4.0.0-beta-23516",
+                "System.Text.Encoding.CodePages": "4.0.1-beta-23516"
+            }
+        }
+    }
+}

--- a/src/NGettext.vs2015.sln
+++ b/src/NGettext.vs2015.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24627.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NGettext", "NGettext\NGettext.xproj", "{014F713D-6A82-42DC-93B7-C216AC53082E}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NGettext.Tests", "NGettext.Tests\NGettext.Tests.xproj", "{4521064C-C0F2-4511-8552-DD7330F3D231}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{014F713D-6A82-42DC-93B7-C216AC53082E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{014F713D-6A82-42DC-93B7-C216AC53082E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{014F713D-6A82-42DC-93B7-C216AC53082E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{014F713D-6A82-42DC-93B7-C216AC53082E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4521064C-C0F2-4511-8552-DD7330F3D231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4521064C-C0F2-4511-8552-DD7330F3D231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4521064C-C0F2-4511-8552-DD7330F3D231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4521064C-C0F2-4511-8552-DD7330F3D231}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NGettext/Catalog.cs
+++ b/src/NGettext/Catalog.cs
@@ -20,7 +20,7 @@ namespace NGettext
 		public Catalog()
 			: base(CultureInfo.CurrentUICulture)
 		{
-			
+
 		}
 
 		/// <summary>
@@ -30,7 +30,7 @@ namespace NGettext
 		public Catalog(CultureInfo cultureInfo)
 			: base(cultureInfo)
 		{
-			
+
 		}
 
 		/// <summary>
@@ -182,12 +182,12 @@ namespace NGettext
 
 		private string _GetFileName(string localeDir, string domain, string locale)
 		{
-			var relativePath =
-				locale.Replace('-', '_') + Path.DirectorySeparatorChar +
-				"LC_MESSAGES" + Path.DirectorySeparatorChar +
-				domain + ".mo";
-
-			return Path.Combine(localeDir, relativePath);
+			return Path.Combine(
+				localeDir,
+				locale.Replace('-', '_'),
+				"LC_MESSAGES",
+				domain + ".mo"
+			);
 		}
 	}
 }

--- a/src/NGettext/Catalog.cs
+++ b/src/NGettext/Catalog.cs
@@ -182,11 +182,13 @@ namespace NGettext
 
 		private string _GetFileName(string localeDir, string domain, string locale)
 		{
+			// mono weirdness
+			var path1 = Path.Combine(localeDir, locale.Replace('-', '_'));
+			var path2 = Path.Combine("LC_MESSAGES", domain + ".mo");
+
 			return Path.Combine(
-				localeDir,
-				locale.Replace('-', '_'),
-				"LC_MESSAGES",
-				domain + ".mo"
+				path1,
+				path2
 			);
 		}
 	}

--- a/src/NGettext/Loaders/ContentType.cs
+++ b/src/NGettext/Loaders/ContentType.cs
@@ -18,9 +18,9 @@ namespace NGettext.Loaders
 		public ContentType(string contentType)
 		{
 			if (contentType == null)
-				throw new ArgumentNullException(nameof(contentType));
+				throw new ArgumentNullException("contentType");
 			if (contentType == String.Empty)
-				throw new ArgumentException("Parameter cannot be an empty string", nameof(contentType));
+				throw new ArgumentException("Parameter cannot be an empty string", "contentType");
 
 			Source = contentType;
 			_parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -35,7 +35,7 @@ namespace NGettext.Loaders
 		public string SubType { get; private set; }
 		public string MediaType
 		{
-			get { return $"${Type}/${MediaType}"; }
+			get { return Type + "/" + MediaType; }
 		}
 
 		public string CharSet { get { return GetParameter("charset"); } }

--- a/src/NGettext/Loaders/ContentType.cs
+++ b/src/NGettext/Loaders/ContentType.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace NGettext.Loaders
+{
+	internal class ContentType
+	{
+		private static readonly Regex Regex = new Regex(@"^(?<type>\w+)\/(?<subType>\w+)(?:\s*;\s*(?<paramName>\w+)\s*=\s*(?<paramValue>(?:[0-9\w_-]+)|(?:"".+ "")))*",
+#if DNXCORE50
+			RegexOptions.IgnoreCase
+#else
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+#endif
+		);
+
+		public ContentType(string contentType)
+		{
+			if (contentType == null)
+				throw new ArgumentNullException(nameof(contentType));
+			if (contentType == String.Empty)
+				throw new ArgumentException("Parameter cannot be an empty string", nameof(contentType));
+
+			Source = contentType;
+			_parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+			ParseValue();
+		}
+
+		private IDictionary<string, string> _parameters;
+
+		public string Source { get; private set; }
+		public string Type { get; private set; }
+		public string SubType { get; private set; }
+		public string MediaType
+		{
+			get { return $"${Type}/${MediaType}"; }
+		}
+
+		public string CharSet { get { return GetParameter("charset"); } }
+
+		public string GetParameter(string name)
+		{
+			string value;
+			_parameters.TryGetValue(name, out value);
+			return value;
+		}
+
+		private void ParseValue()
+		{
+			var match = Regex.Match(Source);
+			if (!match.Success)
+				throw new FormatException("Failed to parse content type: invalid format");
+
+			Type = match.Groups["type"].Value;
+			SubType = match.Groups["subType"].Value;
+
+			var paramNames = match.Groups["paramName"].Captures.Cast<Capture>()
+				.ToArray();
+			var paramValues = match.Groups["paramValue"].Captures.Cast<Capture>()
+				.ToArray();
+
+			for (var i = 0; i < paramNames.Length; i++)
+			{
+				var paramName = paramNames[i];
+				var paramValue = paramValues[i];
+
+				var name = paramName.Value.ToLowerInvariant();
+				var value = paramValue.Value;
+
+				_parameters[name] = value;
+			}
+		}
+	}
+}

--- a/src/NGettext/Loaders/ContentType.cs
+++ b/src/NGettext/Loaders/ContentType.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NGettext.Loaders
@@ -56,15 +55,13 @@ namespace NGettext.Loaders
 			Type = match.Groups["type"].Value;
 			SubType = match.Groups["subType"].Value;
 
-			var paramNames = match.Groups["paramName"].Captures.Cast<Capture>()
-				.ToArray();
-			var paramValues = match.Groups["paramValue"].Captures.Cast<Capture>()
-				.ToArray();
+			var paramNames = match.Groups["paramName"].Captures;
+			var paramValues = match.Groups["paramValue"].Captures;
 
-			for (var i = 0; i < paramNames.Length; i++)
+			for (var i = 0; i < paramNames.Count; i++)
 			{
-				var paramName = paramNames[i];
-				var paramValue = paramValues[i];
+				var paramName = (Capture)paramNames[i];
+				var paramValue = (Capture)paramValues[i];
 
 				var name = paramName.Value.ToLowerInvariant();
 				var value = paramValue.Value;

--- a/src/NGettext/Loaders/MoFileParser.cs
+++ b/src/NGettext/Loaders/MoFileParser.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics;
 using System.IO;
-using System.Net.Mime;
+using System.Text.RegularExpressions;
 
 namespace NGettext.Loaders
 {
@@ -100,7 +100,7 @@ namespace NGettext.Loaders
 					{
 						Trace.WriteLine("Big Endian file detected. Switching readers...", "NGettext");
 						this.IsBigEndian = true;
-						reader.Close();
+						reader.Dispose();
 						reader = new BigEndianBinaryReader(new ReadOnlyStreamWrapper(stream));
 					}
 					else
@@ -157,9 +157,9 @@ namespace NGettext.Loaders
 					if (originalStrings[0].Length == 0)
 					{
 						// MO file metadata processing
-						foreach (var headerText in translatedStrings[0].Split(new []{'\n', '\r'}, StringSplitOptions.RemoveEmptyEntries))
+						foreach (var headerText in translatedStrings[0].Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
 						{
-							var header = headerText.Split(new [] {':'}, 2);
+							var header = headerText.Split(new[] { ':' }, 2);
 							if (header.Length == 2)
 							{
 								this.Headers.Add(header[0], header[1].Trim());
@@ -196,7 +196,7 @@ namespace NGettext.Loaders
 			}
 			finally
 			{
-				reader.Close();
+				reader.Dispose();
 			}
 		}
 
@@ -212,7 +212,7 @@ namespace NGettext.Loaders
 		{
 			reader.BaseStream.Seek(offset, SeekOrigin.Begin);
 			var stringBytes = reader.ReadBytes(length);
-			return this.Encoding.GetString(stringBytes).Split('\0');
+			return this.Encoding.GetString(stringBytes, 0, stringBytes.Length).Split('\0');
 		}
 
 		private static uint _ReverseBytes(uint value)

--- a/src/NGettext/Loaders/MoFileParser.cs
+++ b/src/NGettext/Loaders/MoFileParser.cs
@@ -100,7 +100,11 @@ namespace NGettext.Loaders
 					{
 						Trace.WriteLine("Big Endian file detected. Switching readers...", "NGettext");
 						this.IsBigEndian = true;
+#if DNXCORE50
 						reader.Dispose();
+#else
+						reader.Close();
+#endif
 						reader = new BigEndianBinaryReader(new ReadOnlyStreamWrapper(stream));
 					}
 					else
@@ -196,7 +200,11 @@ namespace NGettext.Loaders
 			}
 			finally
 			{
+#if DNXCORE50
 				reader.Dispose();
+#else
+				reader.Close();
+#endif
 			}
 		}
 

--- a/src/NGettext/Loaders/ReadOnlyStreamWrapper.cs
+++ b/src/NGettext/Loaders/ReadOnlyStreamWrapper.cs
@@ -241,6 +241,10 @@ namespace NGettext.Loaders
 
 #endif
 
+		/// <summary>
+		/// Releases the unmanaged resources used by the System.IO.Stream and optionally releases the managed resources.
+		/// </summary>
+		/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources</param>
 		protected override void Dispose(bool disposing)
 		{
 			if (!this._IsClosed)

--- a/src/NGettext/Loaders/ReadOnlyStreamWrapper.cs
+++ b/src/NGettext/Loaders/ReadOnlyStreamWrapper.cs
@@ -62,7 +62,7 @@ namespace NGettext.Loaders
 		/// When overridden in a derived class, reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
 		/// </summary>
 		/// <returns>
-		/// The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached. 
+		/// The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
 		/// </returns>
 		/// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between <paramref name="offset"/> and (<paramref name="offset"/> + <paramref name="count"/> - 1) replaced by the bytes read from the current source. </param><param name="offset">The zero-based byte offset in <paramref name="buffer"/> at which to begin storing the data read from the current stream. </param><param name="count">The maximum number of bytes to be read from the current stream. </param><exception cref="T:System.ArgumentException">The sum of <paramref name="offset"/> and <paramref name="count"/> is larger than the buffer length. </exception><exception cref="T:System.ArgumentNullException"><paramref name="buffer"/> is null. </exception><exception cref="T:System.ArgumentOutOfRangeException"><paramref name="offset"/> or <paramref name="count"/> is negative. </exception><exception cref="T:System.IO.IOException">An I/O error occurs. </exception><exception cref="T:System.NotSupportedException">The stream does not support reading. </exception><exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception><filterpriority>1</filterpriority>
 		public override int Read(byte[] buffer, int offset, int count)
@@ -152,6 +152,8 @@ namespace NGettext.Loaders
 			}
 		}
 
+#if !DNXCORE50
+
 		/// <summary>
 		/// Begins an asynchronous read operation.
 		/// </summary>
@@ -199,6 +201,8 @@ namespace NGettext.Loaders
 			throw new InvalidOperationException("Stream is in read-only mode.");
 		}
 
+#endif
+
 		/// <summary>
 		/// Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
 		/// </summary>
@@ -221,11 +225,23 @@ namespace NGettext.Loaders
 			throw new InvalidOperationException("Stream is in read-only mode.");
 		}
 
+#if !DNXCORE50
+
 		/// <summary>
 		/// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream.
 		/// </summary>
 		/// <filterpriority>1</filterpriority>
 		public override void Close()
+		{
+			if (!this._IsClosed)
+			{
+				this._IsClosed = true;
+			}
+		}
+
+#endif
+
+		protected override void Dispose(bool disposing)
 		{
 			if (!this._IsClosed)
 			{

--- a/src/NGettext/NGettext.csproj
+++ b/src/NGettext/NGettext.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Loaders\BigEndianBinaryReader.cs" />
     <Compile Include="Loaders\ReadOnlyStreamWrapper.cs" />
     <Compile Include="Loaders\MoFileParser.cs" />
+    <Compile Include="Loaders\ContentType.cs" />
     <Compile Include="Plural\IPluralRule.cs" />
     <Compile Include="Plural\PluralRule.cs" />
     <Compile Include="Plural\IPluralRuleGenerator.cs" />

--- a/src/NGettext/NGettext.xproj
+++ b/src/NGettext/NGettext.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>014f713d-6a82-42dc-93b7-c216ac53082e</ProjectGuid>
+    <RootNamespace>NGettext</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/NGettext/Plural/DefaultPluralRuleGenerator.cs
+++ b/src/NGettext/Plural/DefaultPluralRuleGenerator.cs
@@ -183,14 +183,14 @@ namespace NGettext.Plural
 
 				case "ga":
 					return new PluralRule(5, number => (number == 1) ? 0 : ((number == 2) ? 1 : (((number >= 3) && (number <= 6)) ? 2 : ((number >= 7 && number <= 10) ? 3 : 4))));
-					
+
 				case "ro":
 				case "mo":
 					return new PluralRule(3, number => (number == 1) ? 0 : (((number == 0) || ((number % 100 > 0) && (number % 100 < 20))) ? 1 : 2));
-					
+
 				case "lt":
 					return new PluralRule(3, number => ((number % 10 == 1) && (number % 100 != 11)) ? 0 : (((number % 10 >= 2) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2));
-					
+
 				case "be":
 				case "bs":
 				case "hr":
@@ -199,26 +199,26 @@ namespace NGettext.Plural
 				case "sr":
 				case "uk":
 					return new PluralRule(3, number => ((number % 10 == 1) && (number % 100 != 11)) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2));
-					
+
 				case "cs":
 				case "sk":
 					return new PluralRule(3, number => (number == 1) ? 0 : (((number >= 2) && (number <= 4)) ? 1 : 2));
 
 				case "pl":
 					return new PluralRule(3, number => (number == 1) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 12) || (number % 100 > 14))) ? 1 : 2));
-					
+
 				case "sl":
 					return new PluralRule(4, number => (number % 100 == 1) ? 0 : ((number % 100 == 2) ? 1 : (((number % 100 == 3) || (number % 100 == 4)) ? 2 : 3)));
-					
+
 				case "mt":
 					return new PluralRule(4, number => (number == 1) ? 0 : (((number == 0) || ((number % 100 > 1) && (number % 100 < 11))) ? 1 : (((number % 100 > 10) && (number % 100 < 20)) ? 2 : 3)));
-					
+
 				case "mk":
 					return new PluralRule(2, number => ((number % 10 == 1) && (number != 11)) ? 0 : 1);
 
 				case "cy":
 					return new PluralRule(6, number => (number == 0) ? 0 : ((number == 1) ? 1 : ((number == 2) ? 2 : ((number == 3) ? 3 : ((number == 6) ? 4 : 5)))));
-					
+
 				case "lag":
 				case "ksh":
 					return new PluralRule(3, number => (number == 0) ? 0 : ((number == 1) ? 1 : 2));

--- a/src/NGettext/Properties/AssemblyInfo.cs
+++ b/src/NGettext/Properties/AssemblyInfo.cs
@@ -16,7 +16,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.2.2.1")]
 [assembly: AssemblyFileVersion("0.2.2.1")]
 
+#if !DNXCORE50
 [assembly: Guid("9ef9b9d7-7df8-4c3a-ac8c-58bea65f0526")]
+#endif
 
 [assembly: ComVisible(true)]
 [assembly: CLSCompliant(true)]

--- a/src/NGettext/project.json
+++ b/src/NGettext/project.json
@@ -7,21 +7,23 @@
     "licenseUrl": "https://github.com/neris/NGettext/blob/master/LICENSE",
 
     "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Globalization": "4.0.11-beta-23516",
-        "System.Collections": "4.0.0-beta-23019",
-        "System.IO": "4.0.11-beta-23516",
-        "System.Diagnostics.Debug": "4.0.0-beta-23019",
-        "System.Runtime.Extensions": "4.0.0-beta-23019",
-        "System.Text.RegularExpressions": "4.0.0-beta-23019"
+
     },
 
     "frameworks": {
+        "net20": { },
         "net45": { },
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
+                "System.Runtime": "4.0.21-beta-23516",
+                "System.Globalization": "4.0.11-beta-23516",
+                "System.Collections": "4.0.0-beta-23019",
+                "System.IO": "4.0.11-beta-23516",
+                "System.Diagnostics.Debug": "4.0.0-beta-23019",
+                "System.Runtime.Extensions": "4.0.0-beta-23019",
+                "System.Text.RegularExpressions": "4.0.0-beta-23019",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
                 "System.IO.FileSystem": "4.0.1-beta-23516"
             }
         }

--- a/src/NGettext/project.json
+++ b/src/NGettext/project.json
@@ -13,8 +13,7 @@
         "System.IO": "4.0.11-beta-23516",
         "System.Diagnostics.Debug": "4.0.0-beta-23019",
         "System.Runtime.Extensions": "4.0.0-beta-23019",
-        "System.Text.RegularExpressions": "4.0.0-beta-23019",
-        "System.Linq": "4.0.1-beta-23516"
+        "System.Text.RegularExpressions": "4.0.0-beta-23019"
     },
 
     "frameworks": {

--- a/src/NGettext/project.json
+++ b/src/NGettext/project.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.0-rc1-*",
+    "description": "NGettext",
+    "authors": [ "Neris Ereptoris" ],
+    "tags": [ "gettext", "i18n", "localization" ],
+    "projectUrl": "https://github.com/neris/NGettext",
+    "licenseUrl": "https://github.com/neris/NGettext/blob/master/LICENSE",
+
+    "dependencies": {
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Globalization": "4.0.11-beta-23516",
+        "System.Collections": "4.0.0-beta-23019",
+        "System.IO": "4.0.11-beta-23516",
+        "System.Diagnostics.Debug": "4.0.0-beta-23019",
+        "System.Runtime.Extensions": "4.0.0-beta-23019",
+        "System.Text.RegularExpressions": "4.0.0-beta-23019",
+        "System.Linq": "4.0.1-beta-23516"
+    },
+
+    "frameworks": {
+        "net45": { },
+        "dnx451": { },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
+                "System.IO.FileSystem": "4.0.1-beta-23516"
+            }
+        }
+    }
+}

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "." ],
+  "sdk": {
+    "version": "1.0.0-rc1-final"
+  }
+}


### PR DESCRIPTION
This PR ports the project to the .NET Core, so that it can be used within [ASP.NET 5](https://github.com/aspnet).

Notes:
- added solution for VS 2015
- unit tests are passing under full .NET, but two fail on .NET Core because of unsupported "KOI8-R" encoding
- `ReadOnlyStreamWrapper` now also overrides `Dispose(bool)` next to `Close` since both methods can be called interchangeably and there is no `Close` on .NET Core `Stream`
- `CultureInfo.CreateSpecificCulture(string)` replaced with `new CultureInfo(string)` due to first method not being available in .NET Core and there is no need for the fallback as this method was used only in unit tests
- `Assembly.GetExecutingAssembly().Location` in unit tests replaced with `Directory.GetCurrentDirectory()` - this may cause test fails in different test runners (tested only through NUnit 3 http://www.alteridem.net/2015/11/04/testing-net-core-using-nunit-3/ )
- `System.Net.Mime.ContentType` replaced with custom class `NGettext.Loaders.ContentType` due to first class not being available fro .NET Core